### PR TITLE
refactor: remove redundant homebrew taps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,11 +1,7 @@
 cask_args appdir: "/Applications"
 
 tap "homebrew/bundle"
-tap "homebrew/core"
 tap "homebrew/services"
-tap "homebrew/cask"
-tap "homebrew/cask-fonts"
-tap "homebrew/cask-versions"
 
 tap "1password/tap"
 tap "github/gh"


### PR DESCRIPTION
## Summary

Removes redundant homebrew taps from Brewfile that are automatically included by Homebrew or no longer needed:

- `homebrew/core` - automatically included by default
- `homebrew/cask` - automatically included by default  
- `homebrew/cask-fonts` - automatically included by default
- `homebrew/cask-versions` - automatically included by default

## Changes

- Removes 4 tap declarations from Brewfile
- Maintains all required custom taps (1password/tap, github/gh, homebrew/bundle, homebrew/services)

This cleanup reduces Brewfile verbosity whilst maintaining full functionality.