### PR TITLE
fix: improve install script path portability

### DIFF
--- a/script/install
+++ b/script/install
@@ -14,7 +14,7 @@ check_dependencies() {
     if test "$(uname)" = "Darwin"; then
       echo "  Installing Homebrew for you."
       /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-      echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "/Users/$(whoami)/.zprofile"
+      echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$HOME/.zprofile"
       eval "$(/opt/homebrew/bin/brew shellenv)"
     else
       echo "  You are not running a macOS"


### PR DESCRIPTION
## Summary

This PR improves the portability of the install script by replacing the hardcoded `/Users/$(whoami)` path with the standard `$HOME` environment variable when writing to the `.zprofile` file.

## Changes

- Updated `script/install` line 17 to use `$HOME` instead of `/Users/$(whoami)`
- Follows standard shell scripting best practices for better cross-platform compatibility

## Benefits

- More portable across different Unix-like systems
- Cleaner, more maintainable code
- Follows shell scripting conventions

This is a minor improvement that enhances code quality without changing functionality.