### PR TITLE
fix: remove deprecated homebrew taps

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,5 @@
 cask_args appdir: "/Applications"
 
-tap "homebrew/bundle"
-tap "homebrew/services"
 
 tap "1password/tap"
 tap "github/gh"


### PR DESCRIPTION
## Summary

Removes the deprecated `homebrew/bundle` and `homebrew/services` taps from the Brewfile.

## Background

These taps were deprecated in Homebrew 4.5.0 (April 2025) as the functionality has been moved into Homebrew core:
- `brew bundle` is now a built-in command
- `brew services` is now a built-in command

## Changes

- Removed `tap "homebrew/bundle"` from Brewfile
- Removed `tap "homebrew/services"` from Brewfile

## Impact

This fixes the tap errors users were seeing when running `brew bundle` on newer versions of Homebrew. The functionality remains unchanged as these commands are now built into Homebrew core.