### PR TITLE
fix: improve dot command execution and feedback

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -22,8 +22,13 @@ main() {
   # find the installers and run them iteratively
   find . -name install.sh | egrep -v "homebrew|build" | while read installer; do
     echo "› ${installer}..."
-    sh -c "$installer" >> /tmp/dotfiles-dot
+    sh -c "$installer"
   done
+
+  echo ""
+  echo "✓ Dotfiles update complete!"
+  echo ""
+  echo "Note: To apply macOS defaults, run: ~/.dotfiles/macOS/set-defaults.sh"
 }
 
 main

--- a/node/install.sh
+++ b/node/install.sh
@@ -17,8 +17,7 @@ success() {
 
 # Check if NVM is already installed
 if [ -d "$HOME/.nvm" ]; then
-  info "NVM already installed, skipping..."
-  success "NVM installation check complete"
+  success "NVM already installed, skipping installation"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Fixed output visibility issues in the `dot` command
- Improved NVM installation skip handling
- Added completion feedback

## Problems Addressed
1. **Output was hidden**: The `dot` script was redirecting installer output to `/tmp/dotfiles-dot`, making it appear frozen
2. **No completion feedback**: Users didn't know when the update was complete
3. **Unclear about macOS defaults**: Users didn't know how to run macOS defaults after `dot`

## Changes
- Removed `>> /tmp/dotfiles-dot` redirection so users can see real-time progress
- Simplified NVM already-installed message
- Added completion message with note about macOS defaults script

## Testing
- The `dot` command will now show all output from installers
- NVM installation will clearly skip if already installed
- Users will see a completion message when done

This complements PR #7 which fixes the execute permissions on `node/install.sh`.