### PR TITLE
fix: create VS Code User directory before symlinking settings

### DIFF
--- a/vscode.symlink/install.sh
+++ b/vscode.symlink/install.sh
@@ -3,12 +3,17 @@ if [ "$(uname -s)" != "Darwin" ]; then
   exit 0
 fi
 
-if [ ! -f ~/Library/Application\ Support/Code/User/settings.json ]; then
-  ln -s ~/.vscode/settings.json ~/Library/Application\ Support/Code/User/settings.json
-else
-  rm ~/Library/Application\ Support/Code/User/settings.json
-  ln -s ~/.vscode/settings.json ~/Library/Application\ Support/Code/User/settings.json
+# Create VS Code User directory if it doesn't exist
+VSCODE_USER_DIR=~/Library/Application\ Support/Code/User
+if [ ! -d "$VSCODE_USER_DIR" ]; then
+  mkdir -p "$VSCODE_USER_DIR"
 fi
+
+# Create or update the symlink to settings.json
+if [ -L "$VSCODE_USER_DIR/settings.json" ] || [ -f "$VSCODE_USER_DIR/settings.json" ]; then
+  rm "$VSCODE_USER_DIR/settings.json"
+fi
+ln -s ~/.vscode/settings.json "$VSCODE_USER_DIR/settings.json"
 
 
 if test "$(which code)"; then


### PR DESCRIPTION
## Summary
- Fixed VS Code install script failing with "No such file or directory" error

## Problem
When running `dot` on a fresh system or when VS Code hasn't been opened yet, the script fails because:
- The directory `~/Library/Application Support/Code/User` doesn't exist
- The script tries to create a symlink in this non-existent directory
- This causes the error: `ln: /Users/wayne/Library/Application Support/Code/User/settings.json: No such file or directory`

## Solution
- Added `mkdir -p` to create the VS Code User directory if it doesn't exist
- Improved symlink logic to properly check for both symlinks and regular files
- Used a variable for cleaner code

## Testing
After this fix, the `dot` command will:
- Create the VS Code settings directory if needed
- Successfully create the settings.json symlink
- Continue with VS Code extension installation without errors